### PR TITLE
Add non-persistent volume support

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -40,6 +40,10 @@ module "ecs_scheduled_task" {
   create_ecs_task_execution_role = false
   ecs_task_execution_role_arn    = aws_iam_role.ecs_task_execution.arn
 
+  volumes = [{
+    name = "example-volume"
+  }]
+
   tags = {
     Environment = "prod"
   }

--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,15 @@ resource "aws_ecs_task_definition" "default" {
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#network_mode
   network_mode = "awsvpc"
 
+  # The docker volumes that the task will make available to its containers.
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#volumes
+  dynamic "volume" {
+    for_each = var.volumes
+    content {
+      name = volume.key.name
+    }
+  }
+
   # A mapping of tags to assign to the resource.
   tags = merge({ "Name" = var.name }, var.tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,11 @@ variable "ecs_task_execution_role_arn" {
   type        = string
   description = "The ARN of the ECS Task Execution IAM Role."
 }
+
+variable "volumes" {
+  default = []
+  type = set(object({
+    name = string
+  }))
+  description = "The non-persistent data volumes to be used by the task."
+}


### PR DESCRIPTION
This adds a 'volumes' variable that can drive the 'volume' nested config block.
For now, we'll only add support for non-persistent volumes, since that's all that we need, but this can be easily changed later on.